### PR TITLE
Fix advanced panel

### DIFF
--- a/R/build_pnadc_panel.R
+++ b/R/build_pnadc_panel.R
@@ -95,7 +95,7 @@ build_pnadc_panel <- function(dat, panel) {
           V2005 %in% c("4", "5") & as.numeric(V2009) >= 25 ~ dplyr::cur_group_id()+m,
           TRUE~  id_ind
         ),
-        .by = c(V20081, V2008, V2003)
+        .by = c(id_dom, V20081, V2008, V2003)
       )
     
     # identifying new matched observations


### PR DESCRIPTION
The previous version of the advanced panel was underperforming compared to the basic panel. This did not make sense at all since the individual who had already been matched in 5 interviews simply kept their basic id. Advanced panelling should only be applied to the ones who had not been matched in 5 interviews yet. Therefore, at worst, their performances would be the same (scenario where advanced panelling made no aditional matches).

However, we observed we were only using order number, date and month of birth as criteria for the advanced id. In consequence, multiple people in different households who had those characteristics in common were matched. Those people were lost when we calculated the friction. This should be fized by adding the household identifier (id_dom) as one of the criteria. Indeed, it is one of the criteria for basic panelling.