### PR TITLE
Making advanced ID closer to Stata

### DIFF
--- a/R/build_pnadc_panel.R
+++ b/R/build_pnadc_panel.R
@@ -139,7 +139,7 @@ build_pnadc_panel <- function(dat, panel) {
     dat <- dat %>%
       dplyr::mutate(
         id_rs = ifelse(
-          unmatched_basic & !unmatched_advanced,
+          unmatched_basic & !unmatched_adv,
           id_rs,
           id_ind
         )


### PR DESCRIPTION
To be faithful to Ribas and Soares (2008), we now omit the order number (V2003) from the basic ID. We also change the criteria to be eligible to advanced ID. Position in the household no longer matters and unmatched has a different definition.