### PR TITLE
Add birth date donations

### DIFF
--- a/R/build_pnadc_panel.R
+++ b/R/build_pnadc_panel.R
@@ -3,27 +3,36 @@
 #' This function builds a panel dataset from PNADC data, identifying households and individuals.
 #'
 #' @param dat Data frame with PNADC data, sorted into a single panel.
-#' @param panel A \code{character} with the type of panel identification. Use "none" for no paneling, "basic" for basic paneling, "advanced_1" for advanced stage 1 paneling, and "advanced_2" for advanced stage 2 paneling.
+#' @param panel A \code{character} with the type of panel identification. Use "none" for no paneling, "basic" for basic paneling, "advanced_1" for advanced stage 1 paneling, "advanced_2" for advanced stage 2 paneling, and "advanced_3" for the fuzzy-matching stage 3 paneling.
 #'
-#' @return A modified dataset with added identifiers for household (\code{id_dom}) and individual (\code{id_ind}, and progressively \code{id_rs1} or \code{id_rs2}) based on the chosen panel algorithm.
+#' @return A modified dataset with added identifiers for household (\code{id_dom}) and individual (\code{id_ind}, and progressively \code{id_rs1}, \code{id_rs2}, or \code{id_rs3}) based on the chosen panel algorithm.
 #'
 #' @examplesIf interactive()
 #' # Example usage:
 #' 
-#' panel_data <- build_pnadc_panel(dat = pnad_sample, panel = "advanced_2")
+#' panel_data <- build_pnadc_panel(dat = pnad_sample, panel = "advanced_3")
 #'
 #' @export
 build_pnadc_panel <- function(dat, panel) {
+  
+  func_start_time <- Sys.time()
+  message(sprintf("[%s] Starting build_pnadc_panel with panel type: '%s'", func_start_time, panel))
+  
   ###########################
   ## Bind Global Variables ##
   ###########################
   
   UPA <- V1008 <- V1014 <- id_dom <- V20082 <- V20081 <- V2008 <- V2007 <- NULL
-  Ano <- Trimestre <- id_ind <- num_appearances <- V2003 <- NULL
+  Ano <- Trimestre <- id_ind <- num_appearances <- V2003 <- V2009 <- NULL
   q_count_ind <- NULL
   birth_day <- birth_month <- birth_year <- NULL
-  id_rs1 <- id_rs2 <- num_appearances_rs1 <- num_appearances_rs2 <- NULL
-  q_count_rs1 <- q_count_rs2 <- NULL
+  id_rs1 <- id_rs2 <- id_rs3 <- num_appearances_rs1 <- num_appearances_rs2 <- NULL
+  q_count_rs1 <- q_count_rs2 <- q_count_rs3 <- NULL
+  is_candidate <- row_id <- row_id.A <- row_id.B <- NULL
+  Ano.A <- Ano.B <- Trimestre.A <- Trimestre.B <- NULL
+  V2007.A <- V2007.B <- birth_day.A <- birth_day.B <- NULL
+  birth_month.A <- birth_month.B <- V2009.A <- V2009.B <- NULL
+  id_rs3_fuzzy <- cluster_id <- NULL
   
   #############################
   ## Define Basic Parameters ## 
@@ -31,6 +40,7 @@ build_pnadc_panel <- function(dat, panel) {
   
   # Check if the panel type is 'none'; if so, return the original data
   if (panel == "none") {
+    message(sprintf("[%s] Panel is 'none'. Returning original data unmodified.", Sys.time()))
     return(dat)
   }
   
@@ -40,23 +50,26 @@ build_pnadc_panel <- function(dat, panel) {
   
   # If the panel type is not 'none', perform basic identification steps
   if (panel != "none") {
-    # Household identifier combines UPA, V1008, and V1014, creating an unique number for every combination of those variables, all through the function cur_group_id
+    t_start_basic <- Sys.time()
+    message(sprintf("[%s] --> Starting Basic Identification...", t_start_basic))
+    
+    # Household identifier combines UPA, V1008, and V1014
     dat <- dat %>%
       dplyr::mutate(
         id_dom = dplyr::cur_group_id(),
-        .by = c(UPA, V1008, V1014)
+        .by = c("UPA", "V1008", "V1014")
       )
     
-    # Individual id combines the household id, sex (V2007), and date of birth (V20082, V20081, V2008), creating an unique number for every combination of those variables, all through the function cur_group_id
+    # Individual id combines the household id, sex (V2007), and date of birth
     dat <- dat %>%
       dplyr::mutate(
         id_ind = dplyr::cur_group_id(),
-        .by = c(id_dom, V20082, V20081, V2008, V2007)
+        .by = c("id_dom", "V20082", "V20081", "V2008", "V2007")
       )
     
     # twin removal
     dat <- dat %>%
-      dplyr::add_count(id_ind, Ano, Trimestre, name = "num_appearances") %>% # counts number of times that each id_ind appears
+      dplyr::add_count(id_ind, Ano, Trimestre, name = "num_appearances") %>%
       dplyr::mutate(
         id_ind = dplyr::case_when(
           num_appearances != 1 ~ NA_real_,
@@ -70,24 +83,34 @@ build_pnadc_panel <- function(dat, panel) {
         .default = id_ind
       )
     )
+    
+    t_end_basic <- Sys.time()
+    message(sprintf("[%s] <-- Finished Basic Identification. Time elapsed: %s", t_end_basic, format(round(difftime(t_end_basic, t_start_basic), 2))))
   }
   
   #############################
   ## Advanced Identification ##
   #############################
   
-  if (panel %in% c("advanced_1", "advanced_2")) {
+  if (panel %in% c("advanced_1", "advanced_2", "advanced_3")) {
     
+    t_start_donate <- Sys.time()
+    message(sprintf("[%s] --> Populating birth dates (donate_birth_dates)...", t_start_donate))
     # Call the internal donation function to populate birth_day, birth_month, and birth_year
     dat <- donate_birth_dates(dat)
+    t_end_donate <- Sys.time()
+    message(sprintf("[%s] <-- Finished populating birth dates. Time elapsed: %s", t_end_donate, format(round(difftime(t_end_donate, t_start_donate), 2))))
     
     ## Stage 1:
+    t_start_stg1 <- Sys.time()
+    message(sprintf("[%s] --> Starting Advanced Identification: Stage 1...", t_start_stg1))
+    
     m <- max(dat$id_ind, na.rm = TRUE) # to avoid overlap between id numbers
     
     dat <- dat %>%
       dplyr::mutate(
         id_rs1 = dplyr::cur_group_id() + m,
-        .by = c(id_dom, birth_year, birth_month, birth_day, V2007)
+        .by = c("id_dom", "birth_year", "birth_month", "birth_day", "V2007")
       ) %>%
       # twin removal for stage 1
       dplyr::add_count(id_rs1, Ano, Trimestre, name = "num_appearances_rs1") %>%
@@ -103,11 +126,11 @@ build_pnadc_panel <- function(dat, panel) {
     dat <- dat %>%
       dplyr::mutate(
         q_count_ind = dplyr::n_distinct(interaction(Ano, Trimestre)), 
-        .by = id_ind
+        .by = "id_ind"
       ) %>%
       dplyr::mutate(
         q_count_rs1 = dplyr::n_distinct(interaction(Ano, Trimestre)), 
-        .by = id_rs1
+        .by = "id_rs1"
       ) %>%
       dplyr::mutate(
         # id_rs1 falls back to id_ind if ind performed better or perfectly
@@ -124,14 +147,20 @@ build_pnadc_panel <- function(dat, panel) {
         )
       )
     
+    t_end_stg1 <- Sys.time()
+    message(sprintf("[%s] <-- Finished Stage 1. Time elapsed: %s", t_end_stg1, format(round(difftime(t_end_stg1, t_start_stg1), 2))))
+    
     ## Stage 2:
-    if (panel == "advanced_2") {
+    if (panel %in% c("advanced_2", "advanced_3")) {
+      t_start_stg2 <- Sys.time()
+      message(sprintf("[%s] --> Starting Advanced Identification: Stage 2...", t_start_stg2))
+      
       m2 <- max(dat$id_rs1, na.rm = TRUE) # avoid overlap with Stage 1
       
       dat <- dat %>%
         dplyr::mutate(
           id_rs2 = dplyr::cur_group_id() + m2,
-          .by = c(id_dom, birth_month, birth_day, V2003)
+          .by = c("id_dom", "birth_month", "birth_day", "V2003")
         ) %>%
         # twin removal for stage 2
         dplyr::add_count(id_rs2, Ano, Trimestre, name = "num_appearances_rs2") %>%
@@ -147,7 +176,7 @@ build_pnadc_panel <- function(dat, panel) {
       dat <- dat %>%
         dplyr::mutate(
           q_count_rs2 = dplyr::n_distinct(interaction(Ano, Trimestre)), 
-          .by = id_rs2
+          .by = "id_rs2"
         ) %>%
         dplyr::mutate(
           # id_rs2 falls back to the already-optimized id_rs1
@@ -162,12 +191,125 @@ build_pnadc_panel <- function(dat, panel) {
             TRUE ~ dplyr::coalesce(q_count_rs1, q_count_rs2)
           )
         )
+      
+      t_end_stg2 <- Sys.time()
+      message(sprintf("[%s] <-- Finished Stage 2. Time elapsed: %s", t_end_stg2, format(round(difftime(t_end_stg2, t_start_stg2), 2))))
     }
     
-    # Cleanup auxiliary variables mapped during the advanced stages (KEEPING id_rs1 & id_rs2)
+    ## Stage 3 (Fuzzy Matching):
+    if (panel == "advanced_3") {
+      t_start_stg3 <- Sys.time()
+      message(sprintf("[%s] --> Starting Advanced Identification: Stage 3 (Fuzzy Matching)...", t_start_stg3))
+      
+      if (!requireNamespace("igraph", quietly = TRUE)) {
+        stop("The 'igraph' package is required for the 'advanced_3' panel algorithm. Please install it using install.packages('igraph').")
+      }
+      
+      # 1. Target Candidates (Less than 5 matches in id_rs2)
+      dat <- dat %>%
+        dplyr::mutate(
+          is_candidate = dplyr::coalesce(q_count_rs2 < 5, TRUE),
+          row_id = dplyr::row_number()
+        )
+      
+      candidates <- dat %>% dplyr::filter(is_candidate)
+      
+      # 2. Build the Nest (Self-join within household)
+      nest <- candidates %>%
+        dplyr::select("row_id", "id_dom", "V2007", "birth_day", "birth_month", "V2009", "Ano", "Trimestre") %>%
+        dplyr::inner_join(
+          candidates %>% dplyr::select("row_id", "id_dom", "V2007", "birth_day", "birth_month", "V2009", "Ano", "Trimestre"),
+          by = "id_dom",
+          suffix = c(".A", ".B"),
+          relationship = "many-to-many"
+        ) %>%
+        # Apply strict fuzzy evaluation constraints inside the nest
+        dplyr::filter(
+          row_id.A != row_id.B,
+          interaction(Ano.A, Trimestre.A) != interaction(Ano.B, Trimestre.B),
+          V2007.A == V2007.B,
+          abs(birth_day.A - birth_day.B) <= 4,
+          abs(birth_month.A - birth_month.B) <= 2,
+          abs(V2009.A - V2009.B) <= dplyr::if_else(V2009.A < 25, 2, exp(V2009.A / 30))
+        )
+      
+      # 3. Apply Uniqueness Tie-Breaker
+      valid_matches <- nest %>%
+        dplyr::group_by(row_id.A, Ano.B, Trimestre.B) %>%
+        dplyr::filter(dplyr::n() == 1) %>% 
+        dplyr::ungroup()
+      
+      # 4. Generate Graph & Component IDs
+      if (nrow(valid_matches) > 0) {
+        # Use cbind to ensure a strict 2-column character matrix
+        edges <- cbind(
+          as.character(valid_matches$row_id.A), 
+          as.character(valid_matches$row_id.B)
+        )
+        
+        # Pass the matrix directly; do NOT wrap 'edges' in as.character() here
+        g <- igraph::graph_from_edgelist(edges, directed = FALSE)
+        comps <- igraph::components(g)$membership
+        
+        cluster_map <- data.frame(
+          row_id = as.integer(names(comps)),
+          cluster_id = as.integer(comps)
+        )
+        
+        m3 <- max(dat$id_rs2, na.rm = TRUE)
+        cluster_map$id_rs3_fuzzy <- cluster_map$cluster_id + m3
+        
+        dat <- dat %>%
+          dplyr::left_join(cluster_map, by = "row_id") %>%
+          dplyr::mutate(
+            id_rs3 = dplyr::case_when(
+              !is_candidate ~ id_rs2,
+              !is.na(id_rs3_fuzzy) ~ id_rs3_fuzzy,
+              TRUE ~ id_rs2
+            )
+          )
+      } else {
+        dat <- dat %>% dplyr::mutate(id_rs3 = id_rs2)
+      }
+      
+      # 5. Evaluate and Fallback
+      dat <- dat %>%
+        # Count the ID appearances in the same Year/Quarter (exactly like Stages 1 and 2)
+        dplyr::add_count(id_rs3, Ano, Trimestre, name = "num_appearances_rs3") %>%
+        dplyr::mutate(
+          q_count_rs3 = dplyr::n_distinct(interaction(Ano, Trimestre)), 
+          .by = "id_rs3"
+        ) %>%
+        dplyr::mutate(
+          # id_rs3 falls back to id_rs2 if it generated twins in the quarter OR if rs2 performed better
+          id_rs3 = dplyr::case_when(
+            num_appearances_rs3 > 1 ~ id_rs2, # <- EXPLICIT GUARDRAIL: fallback if multiple rows appear in the same quarter
+            q_count_rs2 == 5 ~ id_rs2,
+            q_count_rs3 > q_count_rs2 & q_count_rs3 <= 5 ~ id_rs3,
+            TRUE ~ dplyr::coalesce(id_rs2, id_rs3)
+          ),
+          q_count_rs3 = dplyr::case_when(
+            num_appearances_rs3 > 1 ~ q_count_rs2, # Adjust the count to reflect the fallback
+            q_count_rs2 == 5 ~ q_count_rs2,
+            q_count_rs3 > q_count_rs2 & q_count_rs3 <= 5 ~ q_count_rs3,
+            TRUE ~ dplyr::coalesce(q_count_rs2, q_count_rs3)
+          )
+        )
+      
+      # Discard the nest and related tracking vars from the environment
+      rm(candidates, nest, valid_matches)
+      
+      t_end_stg3 <- Sys.time()
+      message(sprintf("[%s] <-- Finished Stage 3 (Fuzzy Matching). Time elapsed: %s", t_end_stg3, format(round(difftime(t_end_stg3, t_start_stg3), 2))))
+    }
+    
+    # Cleanup auxiliary variables mapped during the advanced stages (KEEPING id_rs1 & id_rs2 & id_rs3)
     cols_to_remove <- c("num_appearances_rs1", "q_count_rs1", "q_count_ind")
-    if (panel == "advanced_2") {
+    if (panel %in% c("advanced_2", "advanced_3")) {
       cols_to_remove <- c(cols_to_remove, "num_appearances_rs2", "q_count_rs2")
+    }
+    if (panel == "advanced_3") {
+      cols_to_remove <- c(cols_to_remove, "is_candidate", "row_id", "id_rs3_fuzzy", "q_count_rs3")
     }
     dat <- dat %>% dplyr::select(-dplyr::any_of(cols_to_remove))
   }
@@ -175,6 +317,9 @@ build_pnadc_panel <- function(dat, panel) {
   ##########################
   ## Pasting panel number ##
   ##########################
+  
+  t_start_paste <- Sys.time()
+  message(sprintf("[%s] --> Pasting panel numbers...", t_start_paste))
   
   # to avoid overlap when binding more than one panel (all ids are just counts from 1, ..., N)
   # ifelse guards against as.hexmode(NA) which returns the string "NA" instead of a true NA
@@ -189,7 +334,7 @@ build_pnadc_panel <- function(dat, panel) {
   }
   
   # advanced panel 1
-  if (panel %in% c("advanced_1", "advanced_2")) {
+  if (panel %in% c("advanced_1", "advanced_2", "advanced_3")) {
     dat$id_rs1 <- ifelse(
       is.na(dat$id_rs1),
       NA_character_,
@@ -198,7 +343,7 @@ build_pnadc_panel <- function(dat, panel) {
   }
   
   # advanced panel 2
-  if (panel == "advanced_2") {
+  if (panel %in% c("advanced_2", "advanced_3")) {
     dat$id_rs2 <- ifelse(
       is.na(dat$id_rs2),
       NA_character_,
@@ -206,9 +351,24 @@ build_pnadc_panel <- function(dat, panel) {
     )
   }
   
+  # advanced panel 3
+  if (panel == "advanced_3") {
+    dat$id_rs3 <- ifelse(
+      is.na(dat$id_rs3),
+      NA_character_,
+      paste0(as.hexmode(dat$V1014), as.hexmode(dat$id_rs3))
+    )
+  }
+  
+  t_end_paste <- Sys.time()
+  message(sprintf("[%s] <-- Finished pasting panel numbers. Time elapsed: %s", t_end_paste, format(round(difftime(t_end_paste, t_start_paste), 2))))
+  
   #################
   ## Return Data ##
   #################
+  
+  func_end_time <- Sys.time()
+  message(sprintf("[%s] build_pnadc_panel finished successfully. Total Execution Time: %s", func_end_time, format(round(difftime(func_end_time, func_start_time), 2))))
   
   # Return the modified dataset
   return(dat)

--- a/R/build_pnadc_panel.R
+++ b/R/build_pnadc_panel.R
@@ -1,16 +1,16 @@
 #' Build PNADc Panel
 #'
-#' This function builds a panel dataset from PNADC data, identifying households and individuals
+#' This function builds a panel dataset from PNADC data, identifying households and individuals.
 #'
 #' @param dat Data frame with PNADC data, sorted into a single panel.
-#' @param panel A \code{character} with the type of panel identification. Use "none" for no paneling, "basic" for basic paneling, and "advanced" for advanced paneling.
+#' @param panel A \code{character} with the type of panel identification. Use "none" for no paneling, "basic" for basic paneling, "advanced_1" for advanced stage 1 paneling, and "advanced_2" for advanced stage 2 paneling.
 #'
-#' @return A modified dataset with added identifiers for household (\code{id_dom}) and individual (\code{id_ind} or \code{id_rs}) based on the chosen panel algorithm.
+#' @return A modified dataset with added identifiers for household (\code{id_dom}) and individual (\code{id_ind}, and progressively \code{id_rs1} or \code{id_rs2}) based on the chosen panel algorithm.
 #'
 #' @examplesIf interactive()
 #' # Example usage:
 #' 
-#' panel_data <- build_pnadc_panel(dat = pnad_sample, panel = "basic")
+#' panel_data <- build_pnadc_panel(dat = pnad_sample, panel = "advanced_2")
 #'
 #' @export
 build_pnadc_panel <- function(dat, panel) {
@@ -19,8 +19,11 @@ build_pnadc_panel <- function(dat, panel) {
   ###########################
   
   UPA <- V1008 <- V1014 <- id_dom <- V20082 <- V20081 <- V2008 <- V2007 <- NULL
-  Ano <- Trimestre <- id_ind <- num_appearances <- V2003 <- id_rs <- NULL
-  num_appearances_rs <- q_count_ind <- q_count_rs <- NULL
+  Ano <- Trimestre <- id_ind <- num_appearances <- V2003 <- NULL
+  q_count_ind <- NULL
+  birth_day <- birth_month <- birth_year <- NULL
+  id_rs1 <- id_rs2 <- num_appearances_rs1 <- num_appearances_rs2 <- NULL
+  q_count_rs1 <- q_count_rs2 <- NULL
   
   #############################
   ## Define Basic Parameters ## 
@@ -52,7 +55,6 @@ build_pnadc_panel <- function(dat, panel) {
       )
     
     # twin removal
-    
     dat <- dat %>%
       dplyr::add_count(id_ind, Ano, Trimestre, name = "num_appearances") %>% # counts number of times that each id_ind appears
       dplyr::mutate(
@@ -62,7 +64,6 @@ build_pnadc_panel <- function(dat, panel) {
         ))
     
     # missing values
-    
     dat <- dat %>% dplyr::mutate(
       id_ind = dplyr::case_when(
         V2008 == "99" | V20081 == "99" | V20082 == "9999" ~ NA_real_,
@@ -75,68 +76,100 @@ build_pnadc_panel <- function(dat, panel) {
   ## Advanced Identification ##
   #############################
   
-  ## Stage 1:
-  
-  if (!(panel %in% c("none", "basic"))) {
+  if (panel %in% c("advanced_1", "advanced_2")) {
+    
+    # Call the internal donation function to populate birth_day, birth_month, and birth_year
+    dat <- donate_birth_dates(dat)
+    
+    ## Stage 1:
     m <- max(dat$id_ind, na.rm = TRUE) # to avoid overlap between id numbers
-    # id_rs are always higher numbers than id_ind
-    # remove NAs otherwise m is NA and all id_rs are NAs
-    
-    # advanced identification is only run on previously unmatched individuals
     
     dat <- dat %>%
       dplyr::mutate(
-        id_rs = dplyr::cur_group_id() + m,
-        .by = c(id_dom, V20081, V2008, V2003)
-      )
-    
-    # twin removal
-    ## kept here so we remember this step
-    ## in practice it is useless here
-    ## mechanically there are no repeated V2003 in a household/trimestre/year
-    
-    dat <- dat %>%
-      dplyr::add_count(id_rs, Ano, Trimestre, name = "num_appearances_rs") %>% # counts number of times that each id_ind appears
+        id_rs1 = dplyr::cur_group_id() + m,
+        .by = c(id_dom, birth_year, birth_month, birth_day, V2007)
+      ) %>%
+      # twin removal for stage 1
+      dplyr::add_count(id_rs1, Ano, Trimestre, name = "num_appearances_rs1") %>%
       dplyr::mutate(
-        id_rs = dplyr::case_when(
-          num_appearances_rs != 1 ~ NA_real_,
-          .default = id_rs
-        ))
-    
-    # missing values
-    
-    dat <- dat %>% dplyr::mutate(
-      id_rs = dplyr::case_when(
-        V2008 == "99" | V20081 == "99" ~ NA_real_,
-        .default = id_rs
+        id_rs1 = dplyr::case_when(
+          num_appearances_rs1 != 1 ~ NA_real_,
+          is.na(birth_year) | is.na(birth_month) | is.na(birth_day) ~ NA_real_,
+          .default = id_rs1
+        )
       )
-    )
     
+    # Stage 1 evaluation and fallback
     dat <- dat %>%
-      # calculate distinct quarter counts for each ID type
-      # how many times (in diff quarters/years) each ID appears
       dplyr::mutate(
         q_count_ind = dplyr::n_distinct(interaction(Ano, Trimestre)), 
         .by = id_ind
       ) %>%
       dplyr::mutate(
-        q_count_rs = dplyr::n_distinct(interaction(Ano, Trimestre)), 
-        .by = id_rs
+        q_count_rs1 = dplyr::n_distinct(interaction(Ano, Trimestre)), 
+        .by = id_rs1
       ) %>%
       dplyr::mutate(
-        id_rs = dplyr::case_when(
-          # perfect tracking with basic identification
+        # id_rs1 falls back to id_ind if ind performed better or perfectly
+        id_rs1 = dplyr::case_when(
           q_count_ind == 5 ~ id_ind,
-          
-          # id_rs takes over if it finds more quarters than id_ind does
-          # no more than 5 appearances (or else errors are introduced)
-          q_count_rs > q_count_ind & q_count_rs <= 5 ~ id_rs,
-          
-          # fallback: prefer id_ind if available, otherwise keep id_rs
-          TRUE ~ dplyr::coalesce(id_ind, id_rs)
+          q_count_rs1 > q_count_ind & q_count_rs1 <= 5 ~ id_rs1,
+          TRUE ~ dplyr::coalesce(id_ind, id_rs1)
+        ),
+        # Update q_count_rs1 to reflect the merged reality for the potential next stage
+        q_count_rs1 = dplyr::case_when(
+          q_count_ind == 5 ~ q_count_ind,
+          q_count_rs1 > q_count_ind & q_count_rs1 <= 5 ~ q_count_rs1,
+          TRUE ~ dplyr::coalesce(q_count_ind, q_count_rs1)
         )
       )
     
+    ## Stage 2:
+    if (panel == "advanced_2") {
+      m2 <- max(dat$id_rs1, na.rm = TRUE) # avoid overlap with Stage 1
+      
+      dat <- dat %>%
+        dplyr::mutate(
+          id_rs2 = dplyr::cur_group_id() + m2,
+          .by = c(id_dom, birth_month, birth_day, V2003)
+        ) %>%
+        # twin removal for stage 2
+        dplyr::add_count(id_rs2, Ano, Trimestre, name = "num_appearances_rs2") %>%
+        dplyr::mutate(
+          id_rs2 = dplyr::case_when(
+            num_appearances_rs2 != 1 ~ NA_real_,
+            is.na(birth_month) | is.na(birth_day) ~ NA_real_,
+            .default = id_rs2
+          )
+        )
+      
+      # Stage 2 evaluation and fallback
+      dat <- dat %>%
+        dplyr::mutate(
+          q_count_rs2 = dplyr::n_distinct(interaction(Ano, Trimestre)), 
+          .by = id_rs2
+        ) %>%
+        dplyr::mutate(
+          # id_rs2 falls back to the already-optimized id_rs1
+          id_rs2 = dplyr::case_when(
+            q_count_rs1 == 5 ~ id_rs1, 
+            q_count_rs2 > q_count_rs1 & q_count_rs2 <= 5 ~ id_rs2,
+            TRUE ~ dplyr::coalesce(id_rs1, id_rs2)
+          ),
+          q_count_rs2 = dplyr::case_when(
+            q_count_rs1 == 5 ~ q_count_rs1,
+            q_count_rs2 > q_count_rs1 & q_count_rs2 <= 5 ~ q_count_rs2,
+            TRUE ~ dplyr::coalesce(q_count_rs1, q_count_rs2)
+          )
+        )
+    }
+    
+    # Cleanup auxiliary variables mapped during the advanced stages (KEEPING id_rs1 & id_rs2)
+    cols_to_remove <- c("num_appearances_rs1", "q_count_rs1", "q_count_ind")
+    if (panel == "advanced_2") {
+      cols_to_remove <- c(cols_to_remove, "num_appearances_rs2", "q_count_rs2")
+    }
+    dat <- dat %>% dplyr::select(-dplyr::any_of(cols_to_remove))
   }
   
   ##########################
@@ -148,24 +181,29 @@ build_pnadc_panel <- function(dat, panel) {
   
   # basic panel
   if (panel != "none") {
-    
     dat$id_ind <- ifelse(
       is.na(dat$id_ind),
       NA_character_,
       paste0(as.hexmode(dat$V1014), as.hexmode(dat$id_ind))
     )
-    
   }
   
-  # advanced panel
-  if (!(panel %in% c("none", "basic"))) {
-    
-    dat$id_rs <- ifelse(
-      is.na(dat$id_rs),
+  # advanced panel 1
+  if (panel %in% c("advanced_1", "advanced_2")) {
+    dat$id_rs1 <- ifelse(
+      is.na(dat$id_rs1),
       NA_character_,
-      paste0(as.hexmode(dat$V1014), as.hexmode(dat$id_rs))
+      paste0(as.hexmode(dat$V1014), as.hexmode(dat$id_rs1))
     )
-    
+  }
+  
+  # advanced panel 2
+  if (panel == "advanced_2") {
+    dat$id_rs2 <- ifelse(
+      is.na(dat$id_rs2),
+      NA_character_,
+      paste0(as.hexmode(dat$V1014), as.hexmode(dat$id_rs2))
+    )
   }
   
   #################

--- a/R/donate_birth_dates.R
+++ b/R/donate_birth_dates.R
@@ -1,0 +1,114 @@
+#' Donate Birth Dates for PNADC
+#'
+#' This internal function reproduces Rafael Osorio's birth date donation method. 
+#' It estimates and imputes missing birth dates (day, month, and year) by matching 
+#' individuals with donors from different interviews within the same household based 
+#' on sex, acceptable household condition changes, and estimated age.
+#'
+#' @param dat A data frame with PNADC data to be processed.
+#'
+#' @return A modified dataset with donated birth dates replacing missing ones. 
+#' The final dataset includes updated \code{birth_day}, \code{birth_month}, and 
+#' \code{birth_year} variables.
+#' 
+#' @keywords internal
+#' @noRd
+donate_birth_dates <- function(dat) {
+  
+  ###########################
+  ## Bind Global Variables ##
+  ###########################
+  
+  UPA <- V1008 <- V1014 <- id_dom <- V2008 <- V20081 <- V20082 <- NULL
+  Ano <- V2009 <- V2005 <- V2007 <- V1016 <- V1016.x <- V1016.y <- NULL
+  year_missing <- year_estimated <- summarised_condition <- diff <- NULL
+  donor_day <- donor_month <- donor_year <- NULL
+  
+  ##########################################
+  ## Pre-processing & Auxiliary Variables ##
+  ##########################################
+  
+  prep <- dat %>%
+    dplyr::mutate(
+      id_dom = dplyr::cur_group_id(),
+      .by = c(UPA, V1008, V1014)
+    ) %>%
+    dplyr::mutate(
+      # Convert PNADC missing codes (99/9999) to NA
+      V2008  = dplyr::if_else(V2008 == 99, NA_real_, V2008),
+      V20081 = dplyr::if_else(V20081 == 99, NA_real_, V20081),
+      V20082 = dplyr::if_else(V20082 == 9999, NA_real_, V20082),
+      
+      # identifies obs needing donations and donors
+      year_missing = is.na(V20082),
+      
+      # will be compared w donors' years to choose best candidate
+      year_estimated = Ano - V2009,
+      
+      # acceptable household condition interchanges
+      summarised_condition = dplyr::case_when(
+        V2005 %in% c(1, 2, 3) ~ 1,
+        V2005 %in% c(4, 5, 6) ~ 4,
+        V2005 %in% c(8, 9)    ~ 8,
+        TRUE ~ as.numeric(V2005)
+      )
+    )
+  
+  ###########################
+  ## Define the Donor Pool ##
+  ###########################
+  
+  donors <- prep %>%
+    # Potential donors must have a known birth year.
+    dplyr::filter(!year_missing) %>%
+    dplyr::select(id_dom, V1016, V2007, summarised_condition, 
+                  donor_day = V2008, donor_month = V20081, donor_year = V20082)
+  
+  #########################################
+  ## Vectorized Search for Best Donors   ##
+  #########################################
+  
+  # We join by household, sex, and condition group.
+  imputed_matches <- prep %>%
+    dplyr::filter(year_missing) %>%
+    dplyr::left_join(donors, by = c("id_dom", "V2007", "summarised_condition"), 
+                     relationship = "many-to-many") %>%
+    # Apply Step 2.a criteria: different interview and year window
+    dplyr::filter(
+      V1016.x != V1016.y, 
+      abs(donor_year - year_estimated) <= 3
+    ) %>%
+    # Step 2.b: Calculate difference for sorting
+    dplyr::mutate(diff = abs(donor_year - year_estimated)) %>%
+    # Optimized selection: Arrange by person and closest match, then pick first
+    dplyr::arrange(id_dom, V1016.x, V2007, summarised_condition, V2009, diff) %>%
+    dplyr::distinct(id_dom, V1016.x, V2007, summarised_condition, V2009, .keep_all = TRUE)
+  
+  ######################
+  ## Final Merge Back ##
+  ######################
+  
+  # Combine with original data, prioritizing original values where they exist.
+  final_data <- prep %>%
+    dplyr::left_join(
+      imputed_matches %>% 
+        dplyr::select(id_dom, V1016.x, V2007, summarised_condition, V2009, 
+                      donor_day, donor_month, donor_year),
+      by = c("id_dom", "V1016" = "V1016.x", "V2007", "summarised_condition", "V2009")
+    ) %>%
+    # Step 2.c: Fallback logic
+    dplyr::mutate(
+      birth_day   = dplyr::coalesce(V2008, donor_day),
+      birth_month = dplyr::coalesce(V20081, donor_month),
+      birth_year  = dplyr::coalesce(V20082, donor_year)
+    ) %>%
+    # Cleanup auxiliary columns
+    dplyr::select(-donor_day, -donor_month, -donor_year, -year_missing, 
+                  -year_estimated, -summarised_condition, -id_dom)
+  
+  #################
+  ## Return Data ##
+  #################
+  
+  return(final_data)
+}

--- a/R/donate_birth_dates.R
+++ b/R/donate_birth_dates.R
@@ -104,7 +104,7 @@ donate_birth_dates <- function(dat) {
     ) %>%
     # Cleanup auxiliary columns
     dplyr::select(-donor_day, -donor_month, -donor_year, -year_missing, 
-                  -year_estimated, -summarised_condition, -id_dom)
+                  -year_estimated, -summarised_condition)
   
   #################
   ## Return Data ##


### PR DESCRIPTION
- Create donate_birth_dates() function
- Incorporate donation function into build_pnadc_panel

In build_pandc_panel
- id_rs1 created: corresponds to basic id (id_dom, full birth date, sex (V2007)) using donated birth dates instead of original data. Only individuals with missing birth dates receive donations, so this shouldn't affect the ones identified in the basic identifier
- id_rs2 replaced id_rs: uses id_dom, birth day and birth_month and order number (V2003). It uses donated birth dates.

Previously, there was basically no gain between id_ind and id_rs because when the birth year was missing, the entire birth date was missing.