### PR TITLE
Docs: Refine panel methodology documentation, restructure examples, a…

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -48,7 +48,7 @@ devtools::install_github("datazoompuc/datazoom.social")
 devtools::load_all()
 ```
 
-## Data 
+## Functions
 
 <table>
 
@@ -70,7 +70,7 @@ devtools::load_all()
 
 ***
 
-## PNAD Panel Identification
+## PNADC Panel Identification
 
 ```{r child = "vignettes/BUILD_PNADC_PANEL.Rmd"}
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ install.packages("devtools")
 devtools::install_github("datazoompuc/datazoom.social")
 ```
 
-## Data
+## Functions
 
 <table>
 
@@ -100,6 +100,82 @@ e.g. `20121` = 2012 Q1) covered by each PNADC rotating panel:
 |    12 | 20243 | 20263 |
 |    13 | 20254 | 20274 |
 |    14 | 20271 | 20291 |
+
+------------------------------------------------------------------------
+
+**Options:**
+
+1.  **save_to**: The directory in which the user desires to save the
+    downloaded files.
+
+2.  **years**: picks the years for which the data will be downloaded
+
+3.  **quarters**: The quarters within those years to be downloaded. Can
+    be either a vector such as `1:4` for consistent quarters across
+    years, or a list of vectors, if quarters are different for each year
+    (e.g. `list(1:4, 1:2)` for four quarters in the first year and two
+    in the second).
+
+4.  **panel**: Which panel algorithm to apply to this data. There are
+    five options:
+
+    - `none`: No panel is built. If `raw_data = TRUE`, returns the
+      original data. Otherwise, creates some extra treated variables.
+      Quarterly files are saved depending on `save_options`.
+    - `basic`: Performs basic identification steps using household IDs,
+      sex, and exact dates of birth.
+    - `advanced_1`: Performs Stage 1 advanced identification, imputing
+      missing birth dates using within-household donors.
+    - `advanced_2`: Performs Stage 2 advanced identification, relaxing
+      the year of birth constraint.
+    - `advanced_3` (Recommended): Performs Stage 3 advanced
+      identification, utilizing Graph Theory for fuzzy matching of
+      fragmented interviews to account for typographical errors.
+
+5.  **raw_data**: A command to define if the user would like to download
+    the raw or treated data. There are two options:
+
+    - `TRUE`: if you want the PNADC variables as they come.
+    - `FALSE`: if you want the treated version of the PNADC variables.
+
+6.  **save_options**: A logical vector of length 2 controlling file
+    saving behaviour:
+
+    - `c(TRUE, TRUE)` (default): saves quarterly and panel files as
+      `.rds`.
+    - `c(FALSE, TRUE)`: does not save quarterly files; saves panel files
+      as `.rds`.
+    - `c(TRUE, FALSE)`: saves quarterly and panel files as `.parquet`
+      datasets.
+    - `c(FALSE, FALSE)`: does not save quarterly files; saves panel
+      files as a `.parquet` dataset.
+
+7.  **vars**: A character vector of additional variable names to
+    download, following the same convention as `vars` in
+    `PNADcIBGE::get_pnadc()`. Use `NULL` (the default) to download all
+    available microdata columns. See the note above regarding the ~210
+    structural columns that are always returned by
+    `PNADcIBGE::get_pnadc()` regardless of this argument
+
+------------------------------------------------------------------------
+
+**Details:**
+
+The function performs the following steps:
+
+1.  Loop over years and quarters using `PNADcIBGE::get_pnadc` to
+    download the data. All quarters are collected in memory and saved
+    depending on `save_options`.
+2.  Split the data into panels by the panel variable `V1014`.
+3.  Apply the identification algorithms defined in `build_pnadc_panel`.
+4.  Save the panel files as `.rds` or `.parquet`, depending on
+    `save_options`.
+
+- The base identification logic in `build_pnadc_panel` was originally
+  drawn from Ribas, Rafael Perez, and Sergei Suarez Dillon Soares
+  (2008): “Sobre o painel da Pesquisa Mensal de Emprego (PME) do IBGE”,
+  with extensive modernizations, missing-data imputation, and
+  graph-based fuzzy matching introduced by the Data Zoom team.
 
 ------------------------------------------------------------------------
 
@@ -218,85 +294,18 @@ load_pnadc(
 
 ------------------------------------------------------------------------
 
-**Options:**
-
-1.  **save_to**: The directory in which the user desires to save the
-    downloaded files.
-
-2.  **years**: picks the years for which the data will be downloaded
-
-3.  **quarters**: The quarters within those years to be downloaded. Can
-    be either a vector such as `1:4` for consistent quarters across
-    years, or a list of vectors, if quarters are different for each year
-    (e.g. `list(1:4, 1:2)` for four quarters in the first year and two
-    in the second).
-
-4.  **panel**: Which panel algorithm to apply to this data. There are
-    five options:
-
-    - `none`: No panel is built. If `raw_data = TRUE`, returns the
-      original data. Otherwise, creates some extra treated variables.
-      Quarterly files are saved depending on `save_options`.
-    - `basic`: Performs basic identification steps using household IDs,
-      sex, and exact dates of birth.
-    - `advanced_1`: Performs Stage 1 advanced identification, imputing
-      missing birth dates using within-household donors.
-    - `advanced_2`: Performs Stage 2 advanced identification, relaxing
-      the year of birth constraint.
-    - `advanced_3` (Recommended): Performs Stage 3 advanced
-      identification, utilizing Graph Theory for fuzzy matching of
-      fragmented interviews to account for typographical errors.
-
-5.  **raw_data**: A command to define if the user would like to download
-    the raw or treated data. There are two options:
-
-    - `TRUE`: if you want the PNADC variables as they come.
-    - `FALSE`: if you want the treated version of the PNADC variables.
-
-6.  **save_options**: A logical vector of length 2 controlling file
-    saving behaviour:
-
-    - `c(TRUE, TRUE)` (default): saves quarterly and panel files as
-      `.rds`.
-    - `c(FALSE, TRUE)`: does not save quarterly files; saves panel files
-      as `.rds`.
-    - `c(TRUE, FALSE)`: saves quarterly and panel files as `.parquet`
-      datasets.
-    - `c(FALSE, FALSE)`: does not save quarterly files; saves panel
-      files as a `.parquet` dataset.
-
-7.  **vars**: A character vector of additional variable names to
-    download, following the same convention as `vars` in
-    `PNADcIBGE::get_pnadc()`. Use `NULL` (the default) to download all
-    available microdata columns. See the note above regarding the ~210
-    structural columns that are always returned by
-    `PNADcIBGE::get_pnadc()` regardless of this argument
+## PNADC Panel Identification
 
 ------------------------------------------------------------------------
 
-**Details:**
+**Description**
 
-The function performs the following steps:
-
-1.  Loop over years and quarters using `PNADcIBGE::get_pnadc` to
-    download the data. All quarters are collected in memory and saved
-    depending on `save_options`.
-2.  Split the data into panels by the panel variable `V1014`.
-3.  Apply the identification algorithms defined in `build_pnadc_panel`.
-4.  Save the panel files as `.rds` or `.parquet`, depending on
-    `save_options`.
-
-- The base identification logic in `build_pnadc_panel` was originally
-  drawn from Ribas, Rafael Perez, and Sergei Suarez Dillon Soares
-  (2008): “Sobre o painel da Pesquisa Mensal de Emprego (PME) do IBGE”,
-  with extensive modernizations, missing-data imputation, and
-  graph-based fuzzy matching introduced by the Data Zoom team.
-
-------------------------------------------------------------------------
-
-------------------------------------------------------------------------
-
-## PNAD Panel Identification
+Our `load_pnadc` function uses the internal function `build_pnadc_panel`
+to identify households and individuals across quarters. The base method
+used for the identification draws from the paper of Rafael Perez Ribas
+and Sergei Suarez Dillon Soares (2008): “Sobre o painel da Pesquisa
+Mensal de Emprego (PME) do IBGE”, with modernizations implemented by the
+Data Zoom team to handle missing data and typographical errors.
 
 ------------------------------------------------------------------------
 
@@ -320,17 +329,6 @@ panel_data <- build_pnadc_panel(dat = pnad_sample, panel = "advanced_2")
 # Stage 3: Fuzzy matching using Graph Theory (Recommended)
 panel_data <- build_pnadc_panel(dat = pnad_sample, panel = "advanced_3")
 ```
-
-------------------------------------------------------------------------
-
-**Description**
-
-Our `load_pnadc` function uses the internal function `build_pnadc_panel`
-to identify households and individuals across quarters. The base method
-used for the identification draws from the paper of Ribas, Rafael Perez,
-and Sergei Suarez Dillon Soares (2008): “Sobre o painel da Pesquisa
-Mensal de Emprego (PME) do IBGE”, with modernizations implemented by the
-Data Zoom team to handle missing data and typographical errors.
 
 ------------------------------------------------------------------------
 
@@ -364,51 +362,83 @@ On individuals who were not matched across all interviews using the
 basic method, we apply a progressive multi-stage algorithm to increase
 matching power without compromising uniqueness.
 
-- **Stage 1 (`advanced_1`):** We reproduce the birth date donation
-  method (Osório, 2019). It estimates and imputes missing birth dates
-  (day, month, and year) by matching individuals with donors from
-  different interviews within the same household based on sex,
-  acceptable household condition changes, and estimated age. The
-  identifier is stored as `id_rs1`.
+First, we reproduce the birth date donation method based on the
+methodology described in the IPEA technical note (Osório, 2019). It
+estimates and imputes missing birth dates (day, month, and year) by
+matching individuals with donors from different interviews within the
+same household based on sex, acceptable household condition changes, and
+estimated age. This process is executed by our internal function
+`donate_birth_dates`.
+
+- **Stage 1 (`advanced_1`):** Repeats the basic identification logic,
+  but utilizing the donated dates. The identifier – stored as `id_rs1` –
+  combines:
+  - `id_dom` – Household ID
+  - `V2007` – Sex
+  - `birth_day` – Donated day of birth
+  - `birth_month` – Donated month of birth
+  - `birth_year` – Donated year of birth
 - **Stage 2 (`advanced_2`):** For individuals not completely matched in
   Stage 1, we relax the year of birth constraint (assuming it is often
-  misreported) and match individuals based on Household ID, Month, and
-  Day of birth. The identifier is stored as `id_rs2`.
-- **Stage 3 (`advanced_3`):** Applies a rigorous Fuzzy Matching
-  algorithm using Graph Theory (via the `igraph` package). Targeting
-  candidates with fragmented interviews, it evaluates pairwise
-  combinations within the same household. It tolerates small
-  typographical errors (up to 4 days difference in the day of birth, 2
-  months in the month of birth) and dynamically adjusts the acceptable
-  year-of-birth difference based on the individual’s reported age. The
-  final identifier is stored as `id_rs3`.
+  misreported). The identifier – stored as `id_rs2` – combines:
+  - `id_dom` – Household ID
+  - `birth_month` – Donated month of birth
+  - `birth_day` – Donated day of birth
+  - `V2003` – Order number in the household
+- **Stage 3 (`advanced_3`):** Targets candidates with fragmented
+  interviews (less than 5 matches in the previous stages). It considers
+  a match successful if there is a unique individual in the same
+  household, in a different quarter, that satisfies the acceptable
+  difference criteria established by Ribas and Soares (up to 4 days
+  difference in the day of birth, 2 months in the month of birth, and a
+  dynamically adjusted year-of-birth difference based on the
+  individual’s reported age). The final identifier is stored as
+  `id_rs3`.
 
-## Identification Rates
+------------------------------------------------------------------------
 
-The table below shows the average unconditional tracking rates (base
-line) obtained using the basic and advanced identification algorithms
-across multiple panels.
+## Attrition and Identification Rates
 
-*Note: Following the Data Zoom methodological guidelines, we reserve the
-term **Attrition** strictly for the dropout of households. When
-referring to individuals (people), we use the term **Identification
-Rate**. Wave 1 represents the pure initial identification rate (data
-lost exclusively due to the inability to construct a valid identifier or
-household grouping constraints). The subsequent waves (2 to 5) represent
-the cumulative loss of tracked data over time.*
+### 1. Household Attrition Rate
+
+The table below shows the unconditional attrition rate for households.
+This represents the percentage of household units observed in Wave 1
+that were successfully re-interviewed and tracked in subsequent waves.
+
+| Interview (Wave) | Household Attrition Rate (%) |
+|:----------------:|:----------------------------:|
+|        1         |          100.00000           |
+|        2         |           93.75667           |
+|        3         |           91.84360           |
+|        4         |           90.59256           |
+|        5         |           89.60861           |
+
+### 2. Initial Identification Rate (Line-Based)
+
+This table reports the percentage of raw PNADC individual observations
+(lines) **in Wave 1** for which we successfully built a valid
+identifier. Data is lost in this stage exclusively due to the inability
+to construct the identifier (e.g., missing essential data) or household
+grouping constraints.
+
+| Interview (Wave) | Basic Rate (%) | Adv 1 Rate (%) | Adv 2 Rate (%) | Adv 3 Rate (%) |
+|:----------------:|:--------------:|:--------------:|:--------------:|:--------------:|
+|        1         |    93.82378    |    95.82954    |    96.40170    |    96.39606    |
+
+### 3. Individual Unconditional Tracking Rate (ID-Based)
+
+This table demonstrates the cumulative retention of tracked individuals
+over time. It uses the total number of uniquely identified individuals
+from Wave 1 as the universal denominator (starting at 100%), showing how
+much tracking power is gained by using the advanced algorithms.
 
 | Interview (Wave) | Basic Rate (%) | Adv 1 Rate (%) | Adv 2 Rate (%) | Adv 3 Rate (%) | Difference (Adv 3 - Basic) |
 |:--:|:--:|:--:|:--:|:--:|:--:|
-| 1 | 93.82378 | 95.82954 | 96.40170 | 96.39606 | \+ 2.57228 p.p. |
-| 2 | 81.63945 | 84.52960 | 85.32100 | 85.63223 | \+ 3.99278 p.p. |
-| 3 | 75.58231 | 78.90345 | 79.87407 | 80.37762 | \+ 4.79531 p.p. |
-| 4 | 71.13217 | 74.66729 | 75.75082 | 76.39818 | \+ 5.26601 p.p. |
-| 5 | 67.56865 | 71.18041 | 72.31560 | 73.06694 | \+ 5.49829 p.p. |
-
-Each cell in the rate columns represents the percentage of raw PNADC
-individual observations successfully identified and tracked in that
-specific interview, using the total number of raw lines from Wave 1 as
-the universal denominator.
+| 1 | 100.00000 | 100.00000 | 100.00000 | 100.00000 | 0.00000 p.p. |
+| 2 | 87.01360 | 88.20828 | 88.50570 | 88.83374 | \+ 1.82014 p.p. |
+| 3 | 80.55773 | 82.33729 | 82.85546 | 83.38268 | \+ 2.82495 p.p. |
+| 4 | 75.81465 | 77.91677 | 78.57830 | 79.25447 | \+ 3.43982 p.p. |
+| 5 | 72.01655 | 74.27815 | 75.01486 | 75.79868 | \+ 3.78213 p.p. |
 
 ------------------------------------------------------------------------
 

--- a/vignettes/BUILD_PNADC_PANEL.Rmd
+++ b/vignettes/BUILD_PNADC_PANEL.Rmd
@@ -18,6 +18,12 @@ library(datazoom.social)
 ```
 
 ---
+
+**Description**
+
+Our `load_pnadc` function uses the internal function `build_pnadc_panel` to identify households and individuals across quarters. The base method used for the identification draws from the paper of Rafael Perez Ribas and Sergei Suarez Dillon Soares (2008): "Sobre o painel da Pesquisa Mensal de Emprego (PME) do IBGE", with modernizations implemented by the Data Zoom team to handle missing data and typographical errors.
+
+---
   
 **Usage:**
 
@@ -44,12 +50,6 @@ panel_data <- build_pnadc_panel(dat = pnad_sample, panel = "advanced_3")
 
 ---
   
-**Description**
-
-Our `load_pnadc` function uses the internal function `build_pnadc_panel` to identify households and individuals across quarters. The base method used for the identification draws from the paper of Ribas, Rafael Perez, and Sergei Suarez Dillon Soares (2008): "Sobre o painel da Pesquisa Mensal de Emprego (PME) do IBGE", with modernizations implemented by the Data Zoom team to handle missing data and typographical errors.
-
----
-  
 ## Basic Identification
 
 The household identifier -- stored as `id_dom` -- combines the variables:
@@ -70,27 +70,57 @@ The basic individual identifier -- stored as `id_ind` -- combines the household 
 In order to create a unique number for every combination of those variables.
 
 ---
-  
+
 ## Advanced Identification
 
-On individuals who were not matched across all interviews using the basic method, we apply a progressive multi-stage algorithm to increase matching power without compromising uniqueness.
+On individuals who were not matched across all interviews using the basic method, we apply a progressive multi-stage algorithm to increase matching power without compromising uniqueness. 
 
-* **Stage 1 (`advanced_1`):** We reproduce the birth date donation method (Osório, 2019). It estimates and imputes missing birth dates (day, month, and year) by matching individuals with donors from different interviews within the same household based on sex, acceptable household condition changes, and estimated age. The identifier is stored as `id_rs1`.
-* **Stage 2 (`advanced_2`):** For individuals not completely matched in Stage 1, we relax the year of birth constraint (assuming it is often misreported) and match individuals based on Household ID, Month, and Day of birth. The identifier is stored as `id_rs2`.
-* **Stage 3 (`advanced_3`):** Applies a rigorous Fuzzy Matching algorithm using Graph Theory (via the `igraph` package). Targeting candidates with fragmented interviews, it evaluates pairwise combinations within the same household. It tolerates small typographical errors (up to 4 days difference in the day of birth, 2 months in the month of birth) and dynamically adjusts the acceptable year-of-birth difference based on the individual's reported age. The final identifier is stored as `id_rs3`.
+First, we reproduce the birth date donation method based on the methodology described in the IPEA technical note (Osório, 2019). It estimates and imputes missing birth dates (day, month, and year) by matching individuals with donors from different interviews within the same household based on sex, acceptable household condition changes, and estimated age. This process is executed by our internal function `donate_birth_dates`.
 
-## Identification Rates
+* **Stage 1 (`advanced_1`):** Repeats the basic identification logic, but utilizing the donated dates. The identifier -- stored as `id_rs1` -- combines:
+  * `id_dom` -- Household ID
+  * `V2007` -- Sex
+  * `birth_day` -- Donated day of birth
+  * `birth_month` -- Donated month of birth
+  * `birth_year` -- Donated year of birth
 
-The table below shows the average unconditional tracking rates (base line) obtained using the basic and advanced identification algorithms across multiple panels.
+* **Stage 2 (`advanced_2`):** For individuals not completely matched in Stage 1, we relax the year of birth constraint (assuming it is often misreported). The identifier -- stored as `id_rs2` -- combines:
+  * `id_dom` -- Household ID
+  * `birth_month` -- Donated month of birth
+  * `birth_day` -- Donated day of birth
+  * `V2003` -- Order number in the household
 
-*Note: Following the Data Zoom methodological guidelines, we reserve the term **Attrition** strictly for the dropout of households. When referring to individuals (people), we use the term **Identification Rate**. Wave 1 represents the pure initial identification rate (data lost exclusively due to the inability to construct a valid identifier or household grouping constraints). The subsequent waves (2 to 5) represent the cumulative loss of tracked data over time.*
+* **Stage 3 (`advanced_3`):** Targets candidates with fragmented interviews (less than 5 matches in the previous stages). It considers a match successful if there is a unique individual in the same household, in a different quarter, that satisfies the acceptable difference criteria established by Ribas and Soares (up to 4 days difference in the day of birth, 2 months in the month of birth, and a dynamically adjusted year-of-birth difference based on the individual's reported age). The final identifier is stored as `id_rs3`.
+
+***
+
+## Attrition and Identification Rates
+
+### 1. Household Attrition Rate
+The table below shows the unconditional attrition rate for households. This represents the percentage of household units observed in Wave 1 that were successfully re-interviewed and tracked in subsequent waves.
+
+| Interview (Wave) | Household Attrition Rate (%) |
+| :---: | :---: |
+| 1 | 100.00000 |
+| 2 | 93.75667 |
+| 3 | 91.84360 |
+| 4 | 90.59256 |
+| 5 | 89.60861 |
+
+### 2. Initial Identification Rate (Line-Based)
+This table reports the percentage of raw PNADC individual observations (lines) **in Wave 1** for which we successfully built a valid identifier. Data is lost in this stage exclusively due to the inability to construct the identifier (e.g., missing essential data) or household grouping constraints.
+
+| Interview (Wave) | Basic Rate (%) | Adv 1 Rate (%) | Adv 2 Rate (%) | Adv 3 Rate (%) |
+| :---: | :---: | :---: | :---: | :---: |
+| 1 | 93.82378 | 95.82954 | 96.40170 | 96.39606 |
+
+### 3. Individual Unconditional Tracking Rate (ID-Based)
+This table demonstrates the cumulative retention of tracked individuals over time. It uses the total number of uniquely identified individuals from Wave 1 as the universal denominator (starting at 100%), showing how much tracking power is gained by using the advanced algorithms.
 
 | Interview (Wave) | Basic Rate (%) | Adv 1 Rate (%) | Adv 2 Rate (%) | Adv 3 Rate (%) | Difference (Adv 3 - Basic) |
 | :---: | :---: | :---: | :---: | :---: | :---: |
-| 1 | 93.82378 | 95.82954 | 96.40170 | 96.39606 | + 2.57228 p.p. |
-| 2 | 81.63945 | 84.52960 | 85.32100 | 85.63223 | + 3.99278 p.p. |
-| 3 | 75.58231 | 78.90345 | 79.87407 | 80.37762 | + 4.79531 p.p. |
-| 4 | 71.13217 | 74.66729 | 75.75082 | 76.39818 | + 5.26601 p.p. |
-| 5 | 67.56865 | 71.18041 | 72.31560 | 73.06694 | + 5.49829 p.p. |
-
-Each cell in the rate columns represents the percentage of raw PNADC individual observations successfully identified and tracked in that specific interview, using the total number of raw lines from Wave 1 as the universal denominator.
+| 1 | 100.00000 | 100.00000 | 100.00000 | 100.00000 | 0.00000 p.p. |
+| 2 | 87.01360 | 88.20828 | 88.50570 | 88.83374 | + 1.82014 p.p. |
+| 3 | 80.55773 | 82.33729 | 82.85546 | 83.38268 | + 2.82495 p.p. |
+| 4 | 75.81465 | 77.91677 | 78.57830 | 79.25447 | + 3.43982 p.p. |
+| 5 | 72.01655 | 74.27815 | 75.01486 | 75.79868 | + 3.78213 p.p. |

--- a/vignettes/LOAD_PNADC.Rmd
+++ b/vignettes/LOAD_PNADC.Rmd
@@ -40,7 +40,56 @@ The table below shows the first and last quarter (`ANOtrimestre`, e.g. `20121` =
 |    13 | 20254 | 20274 |
 |    14 | 20271 | 20291 |
 
-  ---
+---
+
+**Options:**
+
+  1. **save_to**: The directory in which the user desires to save the downloaded files.
+
+
+  2. **years**: picks the years for which the data will be downloaded
+ 
+
+  3. **quarters**: The quarters within those years to be downloaded. Can be either a vector such as `1:4` for consistent quarters across years, or a list of vectors, if quarters are different for each year (e.g. `list(1:4, 1:2)` for four quarters in the first year and two in the second).
+
+
+  4. **panel**: Which panel algorithm to apply to this data. There are five options:
+  
+     * `none`: No panel is built. If `raw_data = TRUE`, returns the original data. Otherwise, creates some extra treated variables. Quarterly files are saved depending on `save_options`.
+     * `basic`: Performs basic identification steps using household IDs, sex, and exact dates of birth.
+     * `advanced_1`: Performs Stage 1 advanced identification, imputing missing birth dates using within-household donors.
+     * `advanced_2`: Performs Stage 2 advanced identification, relaxing the year of birth constraint.
+     * `advanced_3` (Recommended): Performs Stage 3 advanced identification, utilizing Graph Theory for fuzzy matching of fragmented interviews to account for typographical errors.
+  
+  
+  5. **raw_data**: A command to define if the user would like to download the raw or treated data. There are two options:
+  
+     * `TRUE`: if you want the PNADC variables as they come.
+     * `FALSE`: if you want the treated version of the PNADC variables.
+
+  6. **save_options**: A logical vector of length 2 controlling file saving behaviour:
+  
+     * `c(TRUE, TRUE)` (default): saves quarterly and panel files as `.rds`.
+     * `c(FALSE, TRUE)`: does not save quarterly files; saves panel files as `.rds`.
+     * `c(TRUE, FALSE)`: saves quarterly and panel files as `.parquet` datasets.
+     * `c(FALSE, FALSE)`: does not save quarterly files; saves panel files as a `.parquet` dataset.
+
+  7. **vars**: A character vector of additional variable names to download, following the same convention as `vars` in `PNADcIBGE::get_pnadc()`. Use `NULL` (the default) to download all available microdata columns. See the note above regarding the ~210 structural columns that are always returned by `PNADcIBGE::get_pnadc()` regardless of this argument
+
+---
+  
+**Details:**
+
+The function performs the following steps:
+  
+1. Loop over years and quarters using `PNADcIBGE::get_pnadc` to download the data. All quarters are collected in memory and saved depending on `save_options`.
+2. Split the data into panels by the panel variable `V1014`.
+3. Apply the identification algorithms defined in `build_pnadc_panel`.
+4. Save the panel files as `.rds` or `.parquet`, depending on `save_options`.
+
+* The base identification logic in `build_pnadc_panel` was originally drawn from Ribas, Rafael Perez, and Sergei Suarez Dillon Soares (2008): "Sobre o painel da Pesquisa Mensal de Emprego (PME) do IBGE", with extensive modernizations, missing-data imputation, and graph-based fuzzy matching introduced by the Data Zoom team.
+
+---
 
 **Usage:**
 
@@ -155,54 +204,3 @@ load_pnadc(
 )
 
 ```
-
----
-  
-**Options:**
-
-  1. **save_to**: The directory in which the user desires to save the downloaded files.
-
-
-  2. **years**: picks the years for which the data will be downloaded
- 
-
-  3. **quarters**: The quarters within those years to be downloaded. Can be either a vector such as `1:4` for consistent quarters across years, or a list of vectors, if quarters are different for each year (e.g. `list(1:4, 1:2)` for four quarters in the first year and two in the second).
-
-
-  4. **panel**: Which panel algorithm to apply to this data. There are five options:
-  
-     * `none`: No panel is built. If `raw_data = TRUE`, returns the original data. Otherwise, creates some extra treated variables. Quarterly files are saved depending on `save_options`.
-     * `basic`: Performs basic identification steps using household IDs, sex, and exact dates of birth.
-     * `advanced_1`: Performs Stage 1 advanced identification, imputing missing birth dates using within-household donors.
-     * `advanced_2`: Performs Stage 2 advanced identification, relaxing the year of birth constraint.
-     * `advanced_3` (Recommended): Performs Stage 3 advanced identification, utilizing Graph Theory for fuzzy matching of fragmented interviews to account for typographical errors.
-  
-  
-  5. **raw_data**: A command to define if the user would like to download the raw or treated data. There are two options:
-  
-     * `TRUE`: if you want the PNADC variables as they come.
-     * `FALSE`: if you want the treated version of the PNADC variables.
-
-  6. **save_options**: A logical vector of length 2 controlling file saving behaviour:
-  
-     * `c(TRUE, TRUE)` (default): saves quarterly and panel files as `.rds`.
-     * `c(FALSE, TRUE)`: does not save quarterly files; saves panel files as `.rds`.
-     * `c(TRUE, FALSE)`: saves quarterly and panel files as `.parquet` datasets.
-     * `c(FALSE, FALSE)`: does not save quarterly files; saves panel files as a `.parquet` dataset.
-
-  7. **vars**: A character vector of additional variable names to download, following the same convention as `vars` in `PNADcIBGE::get_pnadc()`. Use `NULL` (the default) to download all available microdata columns. See the note above regarding the ~210 structural columns that are always returned by `PNADcIBGE::get_pnadc()` regardless of this argument
-
----
-  
-**Details:**
-
-The function performs the following steps:
-  
-1. Loop over years and quarters using `PNADcIBGE::get_pnadc` to download the data. All quarters are collected in memory and saved depending on `save_options`.
-2. Split the data into panels by the panel variable `V1014`.
-3. Apply the identification algorithms defined in `build_pnadc_panel`.
-4. Save the panel files as `.rds` or `.parquet`, depending on `save_options`.
-
-* The base identification logic in `build_pnadc_panel` was originally drawn from Ribas, Rafael Perez, and Sergei Suarez Dillon Soares (2008): "Sobre o painel da Pesquisa Mensal de Emprego (PME) do IBGE", with extensive modernizations, missing-data imputation, and graph-based fuzzy matching introduced by the Data Zoom team.
-
----


### PR DESCRIPTION
**Description:**

This PR addresses several documentation improvements in the `README.md` and Vignettes (`LOAD_PNADC` and `BUILD_PNADC_PANEL`) to enhance methodological clarity, readability, and user experience, based on recent review feedback.



**Key Changes:**

* **`load_pnadc` Reorganization:** Moved the usage examples below the parameter definitions so users can read the options before seeing the code implementations.
* **Typo Fix:** Corrected the section header from "PNAD" to "PNADC" in the `build_pnadc_panel` vignette.
* **Advanced Identification Clarity:**
  * **Methodology Context:** Added an introductory paragraph explaining the birth date donation method, explicitly referencing the IPEA technical note (Osório, 2019) and our internal `donate_birth_dates` function.
  * **Variable Breakdown:** Restructured the descriptions of Stage 1 and Stage 2 to use clear bullet points detailing the exact variables used to build the identifiers (e.g., `id_dom`, `V2007`, `birth_day`, etc.), matching the format of the basic identification section.
  * **Simplified Stage 3:** Removed highly technical references to "Graph Theory". The text now focuses on the practical matching logic: confirming a match if there is a unique individual in the same household, in a different quarter, who has less than 5 matches and meets the Ribas and Soares discrepancy criteria.

* **Restructured Identification Rates:** Separated the previously dense tracking table into three distinct, mathematically precise tables to prevent methodological confusion:

  1. **Household Attrition Rate:** Tracks the unconditional attrition for households.
  2. **Initial Identification Rate (Line-Based):** Isolated strictly to Wave 1, showing the percentage of raw lines successfully converted into identifiers.
  3. **Individual Unconditional Tracking Rate (ID-Based):** Tracks cumulative individual retention over time, establishing Wave 1 at a clean 100% baseline to highlight the tracking power gained by the advanced algorithms.



**Why this matters:**
These updates make the underlying matching mechanics transparent and easy to grasp for researchers, while the newly separated tables prevent any ambiguity between household attrition and individual tracking rates.